### PR TITLE
Suppression de la barre d'outils pour les non-admins

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -67,6 +67,9 @@ require get_template_directory() . '/inc/login.php';
 // Synchronisation et améliorations des profils wordpress et buddypress
 require get_template_directory() . '/inc/profile.php';
 
+// Suppression de la barre d'outils pour les non-admins
+require get_template_directory() . '/inc/remove-toolbar.php';
+
 // Customisation du plugin Algolia
 if ( class_exists( 'Algolia_Plugin' ) ) {
 	require get_template_directory() . '/inc/algolia.php';

--- a/inc/remove-toolbar.php
+++ b/inc/remove-toolbar.php
@@ -1,0 +1,11 @@
+<?php
+
+add_action('after_setup_theme', 'tb_remove_toolbar');
+
+function tb_remove_toolbar() {
+	// si besoin, modifier ici pour que d'autres rôles bénéficient de la barre
+	// d'outils (rédacteurs, contributeurs)
+	if ( ! current_user_can('administrator') && ! is_admin() ) {
+		show_admin_bar(false);
+	}
+}


### PR DESCRIPTION
Premier jet pour poser le principe.
Test à ajuster en fonction des rôles à qui on souhaite laisser la barre d'outils.