### PR TITLE
Removes double description from register page

### DIFF
--- a/buddypress/members/register.php
+++ b/buddypress/members/register.php
@@ -241,7 +241,7 @@
 							 */
 							do_action( 'bp_custom_profile_edit_fields' ); ?>
 
-							<p class="description"><?php bp_the_profile_field_description(); ?></p>
+							<!--Commented to remove double description<p class="description">--><?php //bp_the_profile_field_description(); ?><!--</p>-->
 
 						</div>
 


### PR DESCRIPTION
Hello,
This commit will solve double description displayed when user is registering.
Line and comment may be removed.
This has been tested on beta/test and is ok.
Merge and pull please.
Thanks,
Eric