### PR TITLE
Removes double description from edit profile page

### DIFF
--- a/buddypress/members/single/profile/edit.php
+++ b/buddypress/members/single/profile/edit.php
@@ -91,7 +91,7 @@ if ( bp_has_profile( 'profile_group_id=' . bp_get_current_profile_group_id() ) )
 				 */
 				do_action( 'bp_custom_profile_edit_fields' ); ?>
 
-				<p class="description"><?php bp_the_profile_field_description(); ?></p>
+				<!--Commented to remove double description<p class="description">--><?php //bp_the_profile_field_description(); ?><!--</p>-->
 			</div>
 
 		<?php endwhile; ?>


### PR DESCRIPTION
Same as here https://github.com/telabotanica/wp-theme-telabotanica/pull/78 but for editing profile page : removes double description.
Tested with beta/test
Review, merge and pull please.
Thanks,
Eric