### PR TITLE
Fix issue #810

### DIFF
--- a/modules/cover-search/cover-search.php
+++ b/modules/cover-search/cover-search.php
@@ -12,6 +12,34 @@
 	$data = telabotanica_styleguide_data($defaults, $data);
 	$data->modifiers = telabotanica_styleguide_modifiers_array(['cover', 'cover-search'], $data->modifiers);
 
+	// Définir une image au hasard si aucune n'est présente
+	if ( empty( $data->image['url'] ) ) :
+		$cover_image_query = new WP_Query( [
+			'post_status' => 'any',
+			'post_type'   => 'attachment',
+			'tax_query' => [
+				[
+					'taxonomy' => 'media_category',
+					'field'    => 'slug',
+					'terms'    => 'imgbandeau',
+				],
+			],
+			'orderby' => 'rand',
+			'posts_per_page' => 1
+		] );
+		if ( $cover_image_query->have_posts() ) :
+			while ( $cover_image_query->have_posts() ) :
+				$cover_image_query->the_post();
+				$data->image = [
+					'ID' => get_the_ID(),
+					'url' => wp_get_attachment_url( get_the_ID() ),
+					'title' => get_the_title()
+				];
+			endwhile;
+		endif;
+		wp_reset_postdata();
+	endif;
+
 	printf(
 		'<div class="%s" style="background-image: url(%s);">',
 		implode(' ', $data->modifiers),


### PR DESCRIPTION
 Il n'y a actuellement pas d'images de bannière définies pour les pages des résultats de recherche, les image sont donc définies au hasard.