### PR TITLE
footer: add toggle for site map

### DIFF
--- a/modules/button/style.scss
+++ b/modules/button/style.scss
@@ -63,6 +63,11 @@
     &:focus {
       opacity: 0.7;
     }
+
+    &.taupe {
+      // border-color: $taupe;
+      color: $taupe;
+    }
   }
 
   &.link {
@@ -121,6 +126,11 @@
     &.back {
       &::after {display: none;}
     }
+  }
+
+  &.always-block {
+    display: block;
+    width: 100%;
   }
 
   > .icon {

--- a/modules/footer/footer.php
+++ b/modules/footer/footer.php
@@ -34,7 +34,17 @@
       </div>
     </div>
 
-    <?php if ( has_nav_menu( 'footer-columns' ) ) : ?>
+    <div class="footer-nav-toggle">
+      <?php
+      the_telabotanica_module('button', [
+        'text' => __('Plan du site', 'telabotanica'),
+        'modifiers' => ['outline', 'always-block', 'taupe']
+      ]);
+      ?>
+    </div>
+
+    <?php
+    if ( has_nav_menu( 'footer-columns' ) ) : ?>
       <nav class="footer-nav" role="navigation" aria-label="<?php esc_attr_e( 'Plan du site', 'telabotanica' ); ?>">
         <?php
           wp_nav_menu( [

--- a/modules/footer/script.js
+++ b/modules/footer/script.js
@@ -7,13 +7,23 @@ Tela.modules.footer = (function(){
 
   function module(selector){
     var $el     = $(selector),
+      $toggleNav,
+      $nav,
       $itemsMore;
 
     function init(){
+      $toggleNav = $el.find('.footer-nav-toggle button');
+      $nav = $el.find('.footer-nav');
       $itemsMore = $el.find('.menu-item-more');
+
+      $toggleNav.on('click', toggleNav);
 
       var iconArrowRight = iconTemplate({data: {icon: 'arrow-right'}});
       $itemsMore.append(iconArrowRight);
+    }
+
+    function toggleNav(){
+      $nav.toggle();
     }
 
     init();

--- a/modules/footer/style.scss
+++ b/modules/footer/style.scss
@@ -70,6 +70,10 @@
     }
   }
 
+  &-nav-toggle {
+    display: none;
+  }
+
   &-nav {
     background-color: transparentize($gris-f0, 0.5);
     padding: 3.5rem 0;
@@ -195,6 +199,15 @@
 
     &-about-tela-social-item {
       span {display: none;}
+    }
+
+    &-nav-toggle {
+      display: block;
+      margin: 0 2rem 2rem;
+    }
+
+    &-nav {
+      display: none;
     }
 
     &-nav-items {


### PR DESCRIPTION
The site map is now hidden on mobile. There's a button to open it:

![image](https://user-images.githubusercontent.com/38524/41042434-f98f5810-69a1-11e8-9cc3-700a739ca0d3.png)
