### PR TITLE
Fix flash when search is loading + fix toc on flore (taiga 584)

### DIFF
--- a/modules/search-box/scripts/instantsearch.js
+++ b/modules/search-box/scripts/instantsearch.js
@@ -95,14 +95,16 @@ Tela.modules.searchBox.instantsearch = (function(){
           $searchHits.hide();
           $initialContent.show();
         });
+
+        helper.search();
+      } else {
+        helper.search();
+
+        // Show hits
+        $initialContent.hide();
+        $searchFilters.show();
+        $searchHits.show();
       }
-
-      helper.search();
-
-      // Show hits
-      $initialContent.hide();
-      $searchFilters.show();
-      $searchHits.show();
     }
 
     function initSearchBox(){


### PR DESCRIPTION
Currently there is a "flash" (content is hidden, then displayed again) when a page with a search-box is loading. This is a fix for that, which also fixes the problem with the initial state of the `toc`.